### PR TITLE
Fix: style error on multiple choice submission with enter key

### DIFF
--- a/src/pages/TestView.vue
+++ b/src/pages/TestView.vue
@@ -360,8 +360,6 @@ function submitAnswer(d: number = -1) {
     }
 }
 function checkAnswer(d: number = -1) {
-    rightAnswer.value = []
-    wrongAnswer.value = []
     let checkProblemId = d
     if (d !== -1)
         nowAnswer.value = answerList.value[d];
@@ -369,6 +367,8 @@ function checkAnswer(d: number = -1) {
         checkProblemId = nowProblemId.value
     if (problemState.value[checkProblemId] > 1)
         return
+    rightAnswer.value = []
+    wrongAnswer.value = []
     let flag = true
     if (problemState.value[checkProblemId] === -1)
         flag = false


### PR DESCRIPTION
Quick fix for https://github.com/yemaster/vtix-ng/issues/4.

This pull request makes a minor adjustment to the order in which the `rightAnswer` and `wrongAnswer` arrays are cleared in the `checkAnswer` function, moving their reset to just before the answer validation logic.

This helps ensure the arrays are always reset before any answer checking occurs, thus fixing the issue.